### PR TITLE
Add loglevel command line parameter, set successful execution log line to INFO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 MANIFEST
 build/*
 dist/*
+.idea/

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+#----------------------------------- 0.23 ------------------------------------
+[changed] Added log_level command line parameter and changed "executed task"
+logger to log level INFO
 #----------------------------------- 0.22 ------------------------------------
 [fixed] setup.py-based installations. Ran into the bug myself :/
 #----------------------------------- 0.21 ------------------------------------

--- a/rpqueue/__init__.py
+++ b/rpqueue/__init__.py
@@ -764,7 +764,7 @@ def _execute_task(work, conn):
     except:
         log_handler.exception("ERROR: Exception in task %r: %s", to_execute, traceback.format_exc().rstrip())
     else:
-        log_handler.debug("SUCCESS: Task completed: %s %s", taskid, fname)
+        log_handler.info("SUCCESS: Task completed: %s %s", taskid, fname)
 
 def set_priority(queue, qpri, conn=None):
     '''

--- a/rpqueue/__init__.py
+++ b/rpqueue/__init__.py
@@ -58,8 +58,10 @@ REDIS_CONNECTION_SETTINGS = {}
 POOL = None
 PID = None
 
+valid_loglevels = ['DEBUG', 'INFO', 'WARNING', 'ERROR']
 logging.basicConfig()
 log_handler = logging.root
+
 
 def _assert(condition, message, *args):
     if not condition:
@@ -917,6 +919,8 @@ if redis.__version__ >= '2.4':
         help='The unix path to connect to Redis with (use unix path OR host/port, not both')
 cgroup.add_option('--timeout', dest='timeout', action='store', type='int', default=30,
     help='How long to wait for a connection or command to succeed or fail')
+cgroup.add_option('--loglevel', dest='loglevel', action='store', type='string', default='DEBUG',
+    help='Set the default loglevel for logging')
 
 if __name__ == '__main__':
 
@@ -965,6 +969,21 @@ if __name__ == '__main__':
     if (bool(options.clear) + bool(options.page) + bool(options.delete)) > 1:
         print "You can choose at most one of --clear, --page, or --delete"
         sys.exit(1)
+
+    if options.loglevel not in valid_loglevels:
+        print "choose a valid loglevel from {0}".format(valid_loglevels)
+        sys.exit(1)
+
+    if options.loglevel.upper() == 'DEBUG':
+        log_handler.setLevel(logging.DEBUG)
+    elif options.loglevel.upper() == 'INFO':
+        log_handler.setLevel(logging.INFO)
+    elif options.loglevel.upper() == 'WARNING':
+        log_handler.setLevel(logging.WARNING)
+    elif options.loglevel.upper() == 'ERROR':
+        log_handler.setLevel(logging.ERROR)
+    else:
+        log_handler.setLevel(logging.DEBUG)
 
     if options.clear:
         items = clear_queue(options.queue)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except IOError:
 
 setup(
     name='rpqueue',
-    version='0.22',
+    version='0.23',
     description='Use Redis as a priority-enabled and time-based task queue.',
     author='Josiah Carlson',
     author_email='josiah.carlson@gmail.com',


### PR DESCRIPTION
Hey Josiah,

This is Brent from ChowNow. We are trying to get more out of our logging and we were hoping to make the logging for RPQueue a little less verbose. Just allows us to up the log_level to INFO and just see successful execution, errors and exceptions. But I tried to write it so that if you do nothing it should still pretty much operate the same way. Also bumped the version so it would need to get republished since we grab the PyPI version.

Thanks!