### PR TITLE
enable cron_task to save its result

### DIFF
--- a/rpqueue/__init__.py
+++ b/rpqueue/__init__.py
@@ -666,7 +666,8 @@ def cron_task(crontab, queue='default', never_skip=False, attempts=1, retry_dela
     def decorate(function):
         name = '%s.%s'%(function.__module__, function.__name__)
         return _Task(queue, name, function, delay=crontab, never_skip=never_skip,
-                     attempts=attempts, retry_delay=retry_delay)
+                     attempts=attempts, retry_delay=retry_delay,
+                     save_results=save_results)
     return decorate
 
 PREVIOUS = None


### PR DESCRIPTION
When run on a schedule, there is no need to save a task's result; however that same task may also be used in contexts where its results may be inspected. As of now, the `save_results` parameter is ignored; this fixes that apparent omission.