### PR TITLE
logging format contains process id and thread name also

### DIFF
--- a/rpqueue/__init__.py
+++ b/rpqueue/__init__.py
@@ -146,7 +146,8 @@ POOL = None
 
 LOG_LEVELS = dict((v, getattr(logging, v)) for v in ['DEBUG', 'INFO', 'WARNING', 'ERROR'])
 LOG_LEVEL = 'debug'
-logging.basicConfig()
+FORMAT = '%(levelname)s:%(name)s:%(process)s:%(threadName)s:%(message)s'
+logging.basicConfig(format=FORMAT)
 log_handler = logging.root
 
 SUCCESS_LOG_LEVEL = 'debug'


### PR DESCRIPTION
It seems to be useful to add process id and thread name in logging. By using this we can distinguish between logging of different processes and different threads which is very useful in debugging.