### PR TITLE
Exposing redis-py options for SSL/TLS 

### DIFF
--- a/rpqueue/__init__.py
+++ b/rpqueue/__init__.py
@@ -186,7 +186,7 @@ def script_load(script):
     return call
 
 def set_redis_connection_settings(host='localhost', port=6379, db=0,
-    password=None, ssl=False, ssl_ca_certs=None, socket_timeout=30, unix_socket_path=None):
+    password=None, socket_timeout=30, unix_socket_path=None, ssl=False, ssl_ca_certs=None):
     '''
     Sets the global redis connection settings for the queue. If not called
     before use, will connect to localhost:6379 with no password and db 0.

--- a/rpqueue/__init__.py
+++ b/rpqueue/__init__.py
@@ -186,7 +186,7 @@ def script_load(script):
     return call
 
 def set_redis_connection_settings(host='localhost', port=6379, db=0,
-    password=None, socket_timeout=30, unix_socket_path=None):
+    password=None, ssl=False, ssl_ca_certs=None, socket_timeout=30, unix_socket_path=None):
     '''
     Sets the global redis connection settings for the queue. If not called
     before use, will connect to localhost:6379 with no password and db 0.


### PR DESCRIPTION
* Exposing ssl and ssl_ca_certs from redis-py, so rpqueue can connect to TLS enabled Elasticache Redis
* Setting the defaults to False/None as in https://redis-py.readthedocs.io/en/latest/
* following connection string works for me:
```
rpqueue.set_redis_connection_settings('aws_host',6379,4,'a_password', ssl=True, ssl_ca_certs='/some/path/certifi/cacert.pem' )
```
 